### PR TITLE
On unix, create stable short symlinks to each log file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Logging implementation 
+- [unix] create symlinks for latest log files.
 
 ### Changed
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,7 +6,7 @@
   - [x] Writing header
   - [x] Writing log entries
   - [x] Writing backtrace
-  - [ ] Symlinks
+  - [x] Symlinks
   - [ ] Filesize limits
   - [ ] Filerotation
 - [ ] `LOG_IF` macros


### PR DESCRIPTION
Example /tmp/main.INFO -> /tmp/main.hostname.username.log.INFO.<timestamp>

Fixes #20 